### PR TITLE
Add setting to media library to enable/disable blurhash per image

### DIFF
--- a/wp-blurhash.php
+++ b/wp-blurhash.php
@@ -268,7 +268,7 @@ class wp_blurhash {
 	 */
 	public function add_blurhash_media_setting( array $form_fields, WP_Post $post ) {
 		$value        = get_post_meta( $post->ID, 'blurhash', true );
-		$checked_text = $value ? 'checked' : '';
+		$checked_text = $value !== '0' ? 'checked' : '';
 		$html_input   = "<input type='checkbox' $checked_text value='1'
 			name='attachments[{$post->ID}][blurhash]' id='attachments[{$post->ID}][blurhash]' />";
 

--- a/wp-blurhash.php
+++ b/wp-blurhash.php
@@ -43,6 +43,9 @@ class wp_blurhash {
 			add_filter( 'the_content', [ $this, 'filter_content_tags' ] );
 			add_filter( 'wp_blurhash_img_tag_add_adjust', [ $this, 'tag_add_adjust' ], 10, 3 );
 		}
+
+		add_filter( 'attachment_fields_to_edit', [ $this, 'add_blurhash_media_setting' ], 10, 2 );
+		add_filter( 'attachment_fields_to_save', [ $this, 'save_blurhash_media_setting' ], 10, 2);
 	}
 
 	/**
@@ -248,6 +251,43 @@ class wp_blurhash {
 		}
 
 		return $content;
+	}
+
+	/**
+	 * Add checkbox setting to enable/disable blurhash for a given media.
+	 *
+	 * @param array $form_fields
+	 * @param WP_Post $post
+	 *
+	 * @return array
+	 */
+	public function add_blurhash_media_setting( array $form_fields, WP_Post $post ) {
+		$value        = get_post_meta( $post->ID, 'blurhash', true );
+		$checked_text = $value ? 'checked' : '';
+		$html_input   = "<input type='checkbox' $checked_text value='1'
+			name='attachments[{$post->ID}][blurhash]' id='attachments[{$post->ID}][blurhash]' />";
+
+		$form_fields['blurhash'] = array(
+			'label' => __( 'Enable Blurhash',  'wp-blurhash' ),
+			'input' => 'html',
+			'html'  => $html_input,
+		);
+
+		return $form_fields;
+	}
+
+	/**
+	 * Save blurhash setting value for a media post.
+	 *
+	 * @param array $post
+	 * @param array $attachment
+	 *
+	 * @return array
+	 */
+	public function save_blurhash_media_setting( array $post, array $attachment ) {
+		update_post_meta( $post['ID'], 'blurhash', isset( $attachment['blurhash'] ) ? '1' : '0' );
+
+		return $post;
 	}
 
 	/**

--- a/wp-blurhash.php
+++ b/wp-blurhash.php
@@ -268,7 +268,7 @@ class wp_blurhash {
 			name='attachments[{$post->ID}][blurhash]' id='attachments[{$post->ID}][blurhash]' />";
 
 		$form_fields['blurhash'] = array(
-			'label' => __( 'Enable Blurhash',  'wp-blurhash' ),
+			'label' => __( 'Blurhash',  'wp-blurhash' ),
 			'input' => 'html',
 			'html'  => $html_input,
 		);

--- a/wp-blurhash.php
+++ b/wp-blurhash.php
@@ -21,7 +21,6 @@ use kornrunner\Blurhash\Blurhash;
  * Add Blurhash preload support to WordPress.
  *
  * TODO: Add settings to turn on and select method used client-side bg image or canvas.
- * TODO: Add settings to turn on per image in media library.
  * TODO: remove direct calls to GD li / support imagick.
  *       Look at the load function in these files src/wp-includes/class-wp-image-editor.php and src/wp-includes/class-wp-image-editor-imagick.php
  * TODO: add webp GD support.

--- a/wp-blurhash.php
+++ b/wp-blurhash.php
@@ -153,6 +153,11 @@ class wp_blurhash {
 	 */
 	public function tag_add_adjust( $filtered_image, $context, $attachment_id ) {
 
+		$blurhash_setting = get_post_meta( $attachment_id, 'blurhash', true );
+		if ( ! $blurhash_setting ) {
+			return $filtered_image;
+		}
+
 		$image_meta = wp_get_attachment_metadata( $attachment_id );
 
 		if ( isset( $image_meta['blurhash'] ) ) {


### PR DESCRIPTION
This adds a checkbox to allow enabling/disabling on a case by case basis in the media library.

Some design choices to discuss:
1. I've made the checkbox enabled by default. It feels reasonable to assume that if someone activated this plugin, they're looking at using it on most images.
2. The check for the settings value happen right before the images html tag adjustments. This does mean an extra DB call there, which isn't great. Perhaps there's a better way of handling this?
