### PR TITLE
Update wp-blurhash.php

### DIFF
--- a/wp-blurhash.php
+++ b/wp-blurhash.php
@@ -13,7 +13,7 @@
  */
 
 // Your code starts here.
-require_once 'vendor/autoload.php';
+require_once __DIR__ . '/vendor/autoload.php';
 
 use kornrunner\Blurhash\Blurhash;
 


### PR DESCRIPTION
You need to do that if you want your plugin to have its own vendors folder. (guessed depending on your repo.)