### PR TITLE
Handle WebP images using GD

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "require": {
-        "kornrunner/blurhash": "^1.2"
+        "kornrunner/blurhash": "^1.2",
+        "ext-gd": "*"
     }
 }

--- a/wp-blurhash.php
+++ b/wp-blurhash.php
@@ -24,7 +24,6 @@ use kornrunner\Blurhash\Blurhash;
  * TODO: Add settings to turn on per image in media library.
  * TODO: remove direct calls to GD li / support imagick.
  *       Look at the load function in these files src/wp-includes/class-wp-image-editor.php and src/wp-includes/class-wp-image-editor-imagick.php
- * TODO: add webp GD support.
  * TODO: Add tests
  */
 class wp_blurhash {
@@ -93,9 +92,14 @@ class wp_blurhash {
 	}
 
 	public function get_blurhash_by_id( $id ) {
-			$file   = get_attached_file( $id );
+		$file = get_attached_file( $id );
 
-		$image  = imagecreatefromstring( file_get_contents( $file ) );
+		if ( function_exists( 'imagecreatefromwebp' ) && 'image/webp' === wp_get_image_mime( $file ) ) {
+			$image = imagecreatefromwebp( $file );
+		} else {
+			$image = imagecreatefromstring( file_get_contents( $file ) );
+		}
+
 		$width  = imagesx( $image );
 		$height = imagesy( $image );
 


### PR DESCRIPTION
The main complexity was the testing here, so some notes on my findings:

`imagecreatefromwebp` might not be available even if GD extension is enabled. This seems to be due to [this](https://stackoverflow.com/a/48146337).

Interestingly, this is the case when using [Local by Flywheel](https://localwp.com/), while [wp-env](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/) has support for WebP enabled.
 
This is quite convenient for testing both cases easily:
- Local will fallback to use `imagecreatefromstring` which ends up generating a white background image as a blurhash (better than nothing I guess?)
- wp-env will use `imagecreatefromwebp` properly and behaves as expected.
